### PR TITLE
Add compiler and linker flags on mrbgem.rake using sdl2-config

### DIFF
--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,4 +1,7 @@
 MRuby::Gem::Specification.new('mruby-sdl2') do |spec|
   spec.license = 'MIT'
   spec.authors = 'crimsonwoods'
+
+  spec.cc.flags << '`sdl2-config --cflags`'
+  spec.linker.flags << '`sdl2-config --libs`'
 end


### PR DESCRIPTION
@crimsonwoods why not use `sdl2-config` and related compiler and linker flags on the mrbgem file itself? 

I think this way we can reduce configuration on `build_config.rb` and maintain it on the gem.